### PR TITLE
Various fixes for ore processing replacements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,3 +11,5 @@ jobs:
   build-and-test:
     uses: GTNewHorizons/GTNH-Actions-Workflows/.github/workflows/build-and-test.yml@master
     secrets: inherit
+    with:
+      timeout: 180

--- a/src/main/java/com/elisis/gtnhlanth/GTNHLanthanides.java
+++ b/src/main/java/com/elisis/gtnhlanth/GTNHLanthanides.java
@@ -33,7 +33,7 @@ import net.minecraftforge.oredict.OreDictionary;
         dependencies = "required-after:IC2; " + "required-after:gregtech; "
                 + "required-after:bartworks; "
                 + "required-after:GoodGenerator; "
-                + "after:miscutils; "
+                + "before:miscutils; "
                 + "required-after:dreamcraft; ")
 public class GTNHLanthanides {
 

--- a/src/main/java/com/elisis/gtnhlanth/GTNHLanthanides.java
+++ b/src/main/java/com/elisis/gtnhlanth/GTNHLanthanides.java
@@ -33,7 +33,7 @@ import net.minecraftforge.oredict.OreDictionary;
         dependencies = "required-after:IC2; " + "required-after:gregtech; "
                 + "required-after:bartworks; "
                 + "required-after:GoodGenerator; "
-                + "before:miscutils; "
+                + "after:miscutils; "
                 + "required-after:dreamcraft; ")
 public class GTNHLanthanides {
 


### PR DESCRIPTION
- Fix Large Centrifuge and Electrolyzer not updating recipes
- Fix Dehydrator and some of the Electrolyzer recipes not being modified
- Fix cauldron and crafting table can bypass ore processing replacements
- Fix hacky trick with display name

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10339