### PR TITLE
Remove Recipes for LCR Rocket Fuels

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
@@ -1,49 +1,17 @@
 package com.elisis.gtnhlanth.loader;
 
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Acetylhydrazine;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.AmmoniaBoronfluorideSolution;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.AmmoniumDinitramide;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.AmmoniumNitrate;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.AmmoniumNnitrourethane;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.BoronTrifluoride;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.BoronTrioxide;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.DimethylSulfate;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.DinitrogenPentoxide;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.EthylDinitrocarbamate;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.EthylNnitrocarbamate;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Ethylcarbamate;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Ethylchloroformate;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Formaldehyde;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Hydrazine;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.HydrogenPeroxide;
 import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.LMP103S;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Monomethylhydrazine;
 import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.MonomethylhydrazineFuelMix;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Nitromethane;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.NitroniumTetrafluoroborate;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.OXylene;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Phosgene;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.PhthalicAnhydride;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.SodiumFluoride;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.SodiumTetrafluoroborate;
 import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.SodiumTungstate;
 import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.TertButylbenzene;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Tetrafluoroborate;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.Trinitramid;
 import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.TungstenTrioxide;
 import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.TungsticAcid;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.TwoTertButylAnthrahydroquinone;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.TwoTertButylAnthraquinone;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.UnsymmetricalDimethylhydrazine;
 import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.UnsymmetricalDimethylhydrazineFuelMix;
-import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.VanadiumPentoxide;
 import static gregtech.api.enums.OrePrefixes.cell;
 import static gregtech.api.enums.OrePrefixes.dust;
-import static gregtech.api.enums.OrePrefixes.dustTiny;
 import static gregtech.api.enums.OrePrefixes.ingotHot;
 import static gregtech.api.enums.OrePrefixes.item;
 
-import com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool;
 import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import cpw.mods.fml.common.Loader;
 import gregtech.api.enums.GT_Values;
@@ -52,7 +20,6 @@ import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
-import ic2.core.Ic2Items;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -172,7 +139,7 @@ public class BotRecipes {
         // rocket fuels
         // LMP103S
         // 2Cl + CO = COCl2
-        GT_Values.RA.addChemicalRecipe(
+        /*GT_Values.RA.addChemicalRecipe(
                 Materials.CarbonMonoxide.getCells(1),
                 C2,
                 Materials.Chlorine.getGas(2000),
@@ -704,7 +671,7 @@ public class BotRecipes {
                 UnsymmetricalDimethylhydrazineFuelMix.getFluidOrGas(3000),
                 cells,
                 10,
-                120);
+                120);*/
     }
 
     public static void addFuels() {


### PR DESCRIPTION
- Removed the recipes in the processing lines that make the LCR rocket fuels, other than CBD. The fuels should still be usable as before, if they were crafted in advance.

(I put all the recipes in a comment block, I didn't actually remove the code. I tested in a limited mod dev environment, and the full pack, and everything loaded correctly.)

This change is meant to switch rocket fuel production to GT++, and remove some of the many LCR processing chains that cause the LCR spam we all know of. I consider these lines redundant because they were coded in as a replacement option for the GT++ rocket fuels, at a time when GT++ did not allow changes. However, the license has changed since there, so there's little reason to have both paths, especially when they use similar chemicals. The LCR rocket fuels are still usable in rockets as normal, so that people who crafted them in advance do not need to throw them away to make GT++ ones. If this goes through, these fuels can be removed in a later release.

The main argument for this is that GT++ can be changed, however, and as such I am open to suggestions and requests. I'll look deeper into those processing lines and figure out exactly what is needed, and what is not. 