### PR TITLE
Fix ore processing replacement sometimes not working

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/GTNHLanthanides.java
+++ b/src/main/java/com/elisis/gtnhlanth/GTNHLanthanides.java
@@ -17,8 +17,6 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLLoadCompleteEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
-import cpw.mods.fml.common.event.FMLServerStartedEvent;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_Log;
@@ -88,18 +86,8 @@ public class GTNHLanthanides {
         //
         GT_Log.out.print("We are done loading");
         BotRecipes.removeRecipes();
+        RecipeLoader.removeCeriumSources();
 
         GT_Log.out.print("blah blah " + WerkstoffMaterialPool.PTMEGElastomer.hasGenerationFeature(OrePrefixes.ingot));
-    }
-
-    // This is horrifying and I'm sorry
-    @EventHandler
-    public static void onServerAboutToStart(FMLServerAboutToStartEvent e) {
-        // RecipeLoader.removeCeriumSources();
-    }
-
-    @EventHandler
-    public static void onServerStart(FMLServerStartedEvent e) {
-        RecipeLoader.removeCeriumSources();
     }
 }

--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -15,7 +15,6 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.*;
-import gtPlusPlus.xmod.gregtech.loaders.RecipeGen_MultisUsingFluidInsteadOfCells;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -1542,21 +1541,6 @@ public class RecipeLoader {
         GT_Log.out.print("Electrolyzer done!\n");
 
         if (Loader.isModLoaded("miscutils")) {
-            // Blame alk. She made some shit in it, NEI will break down if anyone modify the hash list directly.
-            // For Multi Centrifuge
-            GTPP_Recipe.GTPP_Recipe_Map.sMultiblockCentrifugeRecipes_GT.mRecipeList.clear();
-            RecipeGen_MultisUsingFluidInsteadOfCells.generateRecipesNotUsingCells(
-                    GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes,
-                    GTPP_Recipe.GTPP_Recipe_Map.sMultiblockCentrifugeRecipes_GT);
-            GTPP_Recipe.GTPP_Recipe_Map.sMultiblockCentrifugeRecipes_GT.reInit();
-
-            // For Multi Electrolyzer
-            GTPP_Recipe.GTPP_Recipe_Map.sMultiblockElectrolyzerRecipes_GT.mRecipeList.clear();
-            RecipeGen_MultisUsingFluidInsteadOfCells.generateRecipesNotUsingCells(
-                    GT_Recipe.GT_Recipe_Map.sElectrolyzerRecipes,
-                    GTPP_Recipe.GTPP_Recipe_Map.sMultiblockElectrolyzerRecipes_GT);
-            GTPP_Recipe.GTPP_Recipe_Map.sMultiblockElectrolyzerRecipes_GT.reInit();
-
             // For Simple Washer
             for (GT_Recipe recipe : GTPP_Recipe.GTPP_Recipe_Map.sSimpleWasherRecipes.mRecipeList) {
                 ItemStack input = recipe.mInputs[0];


### PR DESCRIPTION
Some people say even singleblock recipes not showing up, so I guess there's something messy with `FMLServerStartedEvent`.
GT++ generates non-cell recipes on `FMLLoadCompleteEvent` as well, and Lanthanides is loaded before GT++.
@Elisis What's the reason of putting it on `FMLServerStartedEvent` in the first place?