### PR TITLE
(temporarily) disable PTMEG replacement

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/GTNHLanthanides.java
+++ b/src/main/java/com/elisis/gtnhlanth/GTNHLanthanides.java
@@ -6,7 +6,6 @@ import com.elisis.gtnhlanth.common.register.LanthItemList;
 import com.elisis.gtnhlanth.common.register.WerkstoffMaterialPool;
 import com.elisis.gtnhlanth.loader.BotRecipes;
 import com.elisis.gtnhlanth.loader.RecipeLoader;
-import com.elisis.gtnhlanth.loader.ZPMRubberChanges;
 import com.elisis.gtnhlanth.xmod.nei.IMC;
 import com.github.bartimaeusnek.bartworks.API.WerkstoffAdderRegistry;
 import com.github.bartimaeusnek.bartworks.system.material.Werkstoff;
@@ -17,7 +16,6 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLLoadCompleteEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import gregtech.api.GregTech_API;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_Log;
 import java.util.Arrays;
@@ -50,7 +48,7 @@ public class GTNHLanthanides {
         WerkstoffAdderRegistry.addWerkstoffAdder(new WerkstoffMaterialPool());
         WerkstoffAdderRegistry.addWerkstoffAdder(new BotWerkstoffMaterialPool());
         LanthItemList.register();
-        GregTech_API.sAfterGTPostload.add(new ZPMRubberChanges());
+        // GregTech_API.sAfterGTPostload.add(new ZPMRubberChanges());
         proxy.preInit(e);
     }
 


### PR DESCRIPTION
I've found amount of silicone rubber required for UEV conveyor in CompAL recipe is incorrect:
![2022-12-22_01 13 30](https://user-images.githubusercontent.com/40035906/208954639-5fc13dba-1e71-4816-a35f-58e1ae50b2bb.png)

I haven't tracked down the root cause, but disabling PTMEG replacement works:
![2022-12-22_01 22 07](https://user-images.githubusercontent.com/40035906/208954634-9f3e2b71-42c9-4aec-a276-006a5c2fc3ac.png)

Given replacement for assline is somewhat not working and we need next release soon, I'd say disabling the feature is the best thing we can do for now.
