### PR TITLE
Fix broken lanthanum ore processing

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -1238,9 +1238,6 @@ public class RecipeLoader {
                                         tRecipe.mOutputs[i].stackSize * 2,
                                         WerkstoffMaterialPool.SamariumOreConcentrate.get(OrePrefixes.dust, 1));
                                 modified = true;
-                            } else if (tRecipe.mOutputs[i].isItemEqual(Materials.Lanthanum.getDust(1))) {
-                                tRecipe.mOutputs[i] = null;
-                                modified = true;
                             }
                         }
                         if (modified) {


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12217.

Replacing dusts like cerium and samarium is fine but removal like lanthanum just leads to broken recipes.