### PR TITLE
bastlineskip for cerium

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -605,6 +605,16 @@ public class RecipeLoader {
                 0);
 
         // BEGIN Cerium
+        // Cerium Ore + 3HCl = CeCl3 + Monazite Ore (to allow cerium processing without bastnazite/monazite)
+        GT_Values.RA.addChemicalRecipe(
+                WerkstoffMaterialPool.CeriumRichMixture.get(OrePrefixes.dust, 2),
+                null,
+                Materials.HydrochloricAcid.getFluid(3000),
+                Materials.Water.getFluid(3000),
+                WerkstoffMaterialPool.CeriumChloride.get(OrePrefixes.dust, 4),
+                Materials.Monazite.getDust(1),
+                300,
+                450);
         // CeO2 + 3NH4Cl + H = 3NH3 + CeCl3 + 2H2O
         GT_Values.RA.addChemicalRecipe(
                 WerkstoffMaterialPool.CeriumDioxide.get(OrePrefixes.dust, 3),

--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -607,11 +607,11 @@ public class RecipeLoader {
         // BEGIN Cerium
         // Cerium-rich mixture + 3HCl = CeCl3 + Monazite (to allow cerium processing without bastnazite/monazite)
         GT_Values.RA.addChemicalRecipe(
-                WerkstoffMaterialPool.CeriumRichMixture.get(OrePrefixes.dust, 2),
+                WerkstoffMaterialPool.CeriumRichMixture.get(OrePrefixes.dust, 15),
                 null,
-                Materials.HydrochloricAcid.getFluid(3000),
-                Materials.Water.getFluid(3000),
-                WerkstoffMaterialPool.CeriumChloride.get(OrePrefixes.dust, 4),
+                Materials.HydrochloricAcid.getFluid(750),
+                Materials.Water.getFluid(750),
+                WerkstoffMaterialPool.CeriumChloride.get(OrePrefixes.dust, 1),
                 Materials.Monazite.getDust(1),
                 300,
                 450);

--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -605,7 +605,7 @@ public class RecipeLoader {
                 0);
 
         // BEGIN Cerium
-        // Cerium Ore + 3HCl = CeCl3 + Monazite Ore (to allow cerium processing without bastnazite/monazite)
+        // Cerium-rich mixture + 3HCl = CeCl3 + Monazite (to allow cerium processing without bastnazite/monazite)
         GT_Values.RA.addChemicalRecipe(
                 WerkstoffMaterialPool.CeriumRichMixture.get(OrePrefixes.dust, 2),
                 null,


### PR DESCRIPTION
resolves https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12125

Small recipe that allows player to process cerium independently from monazite/bastnazite. Still requires cerium line though, just not bastnazite/monazite line parts.