### PR TITLE
More Lanthanum ore proc fixes

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -1227,9 +1227,6 @@ public class RecipeLoader {
                                         tRecipe.mOutputs[i].stackSize * 2,
                                         WerkstoffMaterialPool.SamariumOreConcentrate.get(OrePrefixes.dust, 1));
                                 modified = true;
-                            } else if (tRecipe.mOutputs[i].isItemEqual(Materials.Lanthanum.getDust(1))) {
-                                tRecipe.mOutputs[i] = null;
-                                modified = true;
                             }
                         }
                         if (modified) {
@@ -1274,9 +1271,6 @@ public class RecipeLoader {
                                 tRecipe.mOutputs[i] = GT_Utility.copyAmount(
                                         tRecipe.mOutputs[i].stackSize * 2,
                                         WerkstoffMaterialPool.SamariumOreConcentrate.get(OrePrefixes.dust, 1));
-                                modified = true;
-                            } else if (tRecipe.mOutputs[i].isItemEqual(Materials.Lanthanum.getDust(1))) {
-                                tRecipe.mOutputs[i] = null;
                                 modified = true;
                             }
                         }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12675.

I missed those in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/49.

Same reasoning: dont replace stuff in recipes with null, it causes problems.