### PR TITLE
patch up europium tier skip

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/common/register/WerkstoffMaterialPool.java
+++ b/src/main/java/com/elisis/gtnhlanth/common/register/WerkstoffMaterialPool.java
@@ -523,6 +523,16 @@ public class WerkstoffMaterialPool implements Runnable {
             offsetID + 49,
             TextureSet.SET_DULL);
 
+    public static final Werkstoff EuropiumIIIOxide = new Werkstoff(
+            new short[] { 255, 230, 255 },
+            "Europium III Oxide",
+            subscriptNumbers("Eu2O3"),
+            new Werkstoff.Stats(),
+            Werkstoff.Types.COMPOUND,
+            new Werkstoff.GenerationFeatures().disable().onlyDust(),
+            offsetID + 50,
+            TextureSet.SET_DULL);
+
     // TODO
 
     // BASTNASITE

--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -620,23 +620,40 @@ public class RecipeLoader {
         GT_Values.RA.addElectromagneticSeparatorRecipe(
                 WerkstoffMaterialPool.CooledMonaziteRareEarthConcentrate.get(OrePrefixes.dust, 1),
                 WerkstoffMaterialPool.MonaziteRarerEarthSediment.get(OrePrefixes.dust, 1),
-                WerkstoffMaterialPool.EuropiumOxide.get(OrePrefixes.dust, 2), // Maybe also holmium
+                WerkstoffMaterialPool.EuropiumIIIOxide.get(OrePrefixes.dust, 5), // Maybe also holmium
                 null,
                 new int[] { 9000, 500 },
                 600,
                 1920);
 
-        // EuO + H2S = EuS + H2O
+        // 5Eu2O3 + Eu = 4EuO
         GT_Values.RA.addChemicalRecipe(
-                WerkstoffMaterialPool.EuropiumOxide.get(OrePrefixes.dust, 2),
+                WerkstoffMaterialPool.EuropiumIIIOxide.get(OrePrefixes.dust, 5),
+                Materials.Europium.getDust(1),
                 null,
-                Materials.HydricSulfide.getGas(1000),
-                Materials.Water.getFluid(1000),
-                WerkstoffMaterialPool.EuropiumSulfide.get(OrePrefixes.dust, 2),
-                300,
+                null,
+                WerkstoffMaterialPool.EuropiumOxide.get(OrePrefixes.dust, 4),
+                600,
                 8400);
 
+        // 4 EuO = 2 Eu + 2O2
+        GT_Values.RA.addElectrolyzerRecipe(
+                WerkstoffMaterialPool.EuropiumOxide.get(OrePrefixes.dust, 2),
+                null,
+                null,
+                Materials.Oxygen.getGas(1000L),
+                Materials.Europium.getDust(1),
+                null,
+                null,
+                null,
+                null,
+                null,
+                new int[] { 10000, 10000 },
+                300,
+                33000);
+
         // EuS = Eu + S
+        // TODO old recipe. for compat only. remove material and recipe half a year later, i.e. after September 2023.
         GT_Values.RA.addElectrolyzerRecipe(
                 WerkstoffMaterialPool.EuropiumSulfide.get(OrePrefixes.dust, 2),
                 null,

--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -633,7 +633,7 @@ public class RecipeLoader {
                 null,
                 null,
                 WerkstoffMaterialPool.EuropiumOxide.get(OrePrefixes.dust, 4),
-                600,
+                300,
                 8400);
 
         // 4 EuO = 2 Eu + 2O2


### PR DESCRIPTION
The updated recipe chain require europium dust as an input, so no one can use this method to bypass fusion requirement on europium gate.

See https://discord.com/channels/181078474394566657/939305179524792340/1073185513059647588 for more context.

Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12416

Old recipe:
```
.... =>5% 2x EuO
2EuO + H2S => 2EuS + H2O
2EuS => Eu + S
```
![image](https://user-images.githubusercontent.com/4586901/225077352-c52577f2-5e2a-401a-a54e-2a43e8d1850d.png)
![image](https://user-images.githubusercontent.com/4586901/225077462-340abe94-3d61-4acd-a29c-96fb77ed8dad.png)
![image](https://user-images.githubusercontent.com/4586901/225077552-c7a7ece9-6422-4961-a305-b1d5056744eb.png)

Net yield 0.05 Eu dust per craft.

New recipe:
```
... => 5% 5x Eu2O3
5 Eu2O3 + Eu => 4 EuO
2 EuO => Eu + O2
```
![image](https://user-images.githubusercontent.com/4586901/225079241-9eeaaa31-6c97-4f00-809a-92680bacf409.png)
![image](https://user-images.githubusercontent.com/4586901/225080401-3416ed8a-40d8-4995-b1d2-cda5cfa2dbc7.png)
![image](https://user-images.githubusercontent.com/4586901/225079470-6aa9f8ed-8ab6-4824-b629-8a92c71ce256.png)

Net yield 0.05 Eu dust per craft.

Recipe time are chosen to keep the overall process take as long as it used to under same overclock conditions.