### PR TITLE
Phosgene Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1682616243
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,8 +69,11 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
 }
+
+print("You might want to check out './gradlew :faq' if your build fails.\n")
+
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
 if (settingsupdated)
@@ -219,6 +222,8 @@ if (enableModernJavaSyntax.toBoolean()) {
 
     dependencies {
         annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
+        // workaround for https://github.com/bsideup/jabel/issues/174
+        annotationProcessor 'net.java.dev.jna:jna-platform:5.13.0'
         compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
@@ -564,9 +569,10 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.6"
+def mixinProviderVersion = "0.1.7.1"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
+ext.mixinProviderSpec = mixinProviderSpec
 
 dependencies {
     if (usesMixins.toBoolean()) {
@@ -724,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -816,6 +822,18 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
             !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
         }
         this.classpath(project.java17DependenciesCfg)
+    }
+
+    public void setup(Project project) {
+        super.setup(project)
+        if (project.usesMixins.toBoolean()) {
+            this.extraJvmArgs.addAll(project.provider(() -> {
+                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(project.mixinProviderSpec))
+                mixinCfg.canBeConsumed = false
+                mixinCfg.transitive = false
+                enableHotswap ? ["-javaagent:" + mixinCfg.singleFile.absolutePath] : []
+            }))
+        }
     }
 }
 
@@ -1249,6 +1267,23 @@ if (!project.getGradle().startParameter.isOffline() && !Boolean.getBoolean('DISA
         if (gradle.gradleVersion != buildscriptGradleVersion) {
             out.style(Style.SuccessHeader).println("updateBuildScript can update gradle from ${gradle.gradleVersion} to ${buildscriptGradleVersion}\n")
         }
+    }
+}
+
+// If you want to add more cases to this task, implement them as arguments if total amount to print gets too large
+tasks.register('faq') {
+    group = 'GTNH Buildscript'
+    description = 'Prints frequently asked questions about building a project'
+
+    doLast {
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
+            "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,33 +1,33 @@
 // Add your dependencies here
 
 dependencies {
-    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.07:dev')
-    compile('com.github.GTNewHorizons:NewHorizonsCoreMod:2.1.0:dev')
-    compile('com.github.GTNewHorizons:StructureLib:1.2.6:dev')
-    compile('com.github.GTNewHorizons:GTplusplus:1.9.1:dev')
-    compile('com.github.GTNewHorizons:GoodGenerator:0.6.1:dev')
-    compile('com.github.GTNewHorizons:TecTech:5.2.1:dev')
+    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.65:dev')
+    compile('com.github.GTNewHorizons:NewHorizonsCoreMod:2.1.44:dev')
+    compile('com.github.GTNewHorizons:StructureLib:1.2.7:dev')
+    compile('com.github.GTNewHorizons:GTplusplus:1.9.28:dev')
+    compile('com.github.GTNewHorizons:GoodGenerator:0.6.9:dev')
+    compile('com.github.GTNewHorizons:TecTech:5.2.20:dev')
     compile('com.github.GTNewHorizons:ForestryMC:4.6.7:dev')
-    compile('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-197-GTNH:dev')
-    compile('com.github.GTNewHorizons:bartworks:0.7.1:dev')
+    compile('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-217-GTNH:dev')
+    compile('com.github.GTNewHorizons:bartworks:0.7.15:dev')
     compile('com.github.GTNewHorizons:BuildCraft:7.1.33:dev')
-    compile('com.github.GTNewHorizons:NotEnoughItems:2.3.46-GTNH:dev')
+    compile('com.github.GTNewHorizons:NotEnoughItems:2.3.54-GTNH:dev')
 
     compile('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
 
-    compileOnly('com.github.GTNewHorizons:EnderCore:0.2.13:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:EnderCore:0.2.14:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:AppleCore:3.2.10:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:Railcraft:9.14.1:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:EnderIO:2.4.11:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.33:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:Railcraft:9.14.3:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:EnderIO:2.4.17:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.34:dev') {transitive=false}
 
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev') {transitive=false}
 
-    //compile('com.github.GTNewHorizons:GalacticGregGT5:1.0.8:dev')
-    //compile('com.github.GTNewHorizons:TecTech:5.2.1:dev')
+    //compile('com.github.GTNewHorizons:GalacticGregGT5:1.0.9:dev')
+    //compile('com.github.GTNewHorizons:TecTech:5.2.20:dev')
     //compile('com.github.GTNewHorizons:Galacticraft:3.0.68-GTNH:dev')
 
-    //compileOnly('com.github.GTNewHorizons:Avaritia:1.39)
+    //compileOnly('com.github.GTNewHorizons:Avaritia:1.42
 
     //compile files('ThaumicTinkerer-1.7.10-2.7-0-dev.jar')
 

--- a/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
@@ -2,6 +2,10 @@ package com.elisis.gtnhlanth.loader;
 
 import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.*;
 import static gregtech.api.enums.OrePrefixes.*;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sChemicalRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
+import static gregtech.api.util.GT_RecipeConstants.UniversalChemical;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -19,6 +23,7 @@ import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import cpw.mods.fml.common.Loader;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
@@ -140,77 +145,21 @@ public class BotRecipes {
         // rocket fuels
         // LMP103S
         // 2Cl + CO = COCl2
-        GT_Values.RA.addChemicalRecipe(
-                Materials.CarbonMonoxide.getCells(1),
-                C2,
-                Materials.Chlorine.getGas(2000),
-                null,
-                Phosgene.get(cell, 1),
-                50,
-                480);
-        GT_Values.RA.addChemicalRecipe(
-                Materials.Chlorine.getCells(2),
-                C2,
-                Materials.CarbonMonoxide.getGas(1000),
-                null,
-                Phosgene.get(cell, 1),
-                Materials.Empty.getCells(1),
-                50,
-                480);
-        GT_Values.RA.addChemicalRecipe(
-                Materials.CarbonMonoxide.getCells(1),
-                C2,
-                Materials.Chlorine.getGas(2000),
-                BotWerkstoffMaterialPool.Phosgene.getFluidOrGas(1000),
-                null,
-                Materials.Empty.getCells(1),
-                50,
-                480);
-        GT_Values.RA.addChemicalRecipe(
-                Materials.Chlorine.getCells(2),
-                C2,
-                Materials.CarbonMonoxide.getGas(1000),
-                BotWerkstoffMaterialPool.Phosgene.getFluidOrGas(1000),
-                null,
-                Materials.Empty.getCells(2),
-                50,
-                480);
-        GT_Values.RA.addChemicalRecipe(
-                Materials.CarbonMonoxide.getCells(1),
-                Materials.Chlorine.getCells(2),
-                null,
-                null,
-                Phosgene.get(cell, 1),
-                Materials.Empty.getCells(2),
-                50,
-                480);
-        GT_Values.RA.addChemicalRecipe(
-                Materials.Chlorine.getCells(2),
-                Materials.CarbonMonoxide.getCells(1),
-                null,
-                null,
-                Phosgene.get(cell, 1),
-                Materials.Empty.getCells(2),
-                50,
-                480);
-        GT_Values.RA.addChemicalRecipe(
-                Materials.CarbonMonoxide.getCells(1),
-                Materials.Chlorine.getCells(2),
-                null,
-                BotWerkstoffMaterialPool.Phosgene.getFluidOrGas(1000),
-                null,
-                Materials.Empty.getCells(3),
-                50,
-                480);
-        GT_Values.RA.addChemicalRecipe(
-                Materials.Chlorine.getCells(2),
-                Materials.CarbonMonoxide.getCells(1),
-                null,
-                BotWerkstoffMaterialPool.Phosgene.getFluidOrGas(1000),
-                null,
-                Materials.Empty.getCells(3),
-                50,
-                480);
+
+        GT_Values.RA.stdBuilder().itemInputs(Materials.CarbonMonoxide.getCells(1), GT_Utility.getIntegratedCircuit(12))
+                .itemOutputs(Phosgene.get(cell, 1)).fluidInputs(Materials.Chlorine.getGas(2000)).noFluidOutputs()
+                .duration(2 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_HV).addTo(sChemicalRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(Materials.Chlorine.getCells(2), GT_Utility.getIntegratedCircuit(12))
+                .itemOutputs(Phosgene.get(cell, 1), Materials.Empty.getCells(1))
+                .fluidInputs(Materials.CarbonMonoxide.getGas(1000)).noFluidOutputs().duration(2 * SECONDS + 10 * TICKS)
+                .eut(TierEU.RECIPE_HV).addTo(sChemicalRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(Materials.CarbonMonoxide.getCells(1), Materials.Chlorine.getCells(2))
+                .itemOutputs(Phosgene.get(cell, 1), Materials.Empty.getCells(2)).noFluidInputs().noFluidOutputs()
+                .duration(2 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_HV).addTo(sChemicalRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(Materials.Chlorine.getCells(2), GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(Materials.Empty.getCells(2)).fluidInputs(Materials.CarbonMonoxide.getGas(1000))
+                .fluidOutputs(BotWerkstoffMaterialPool.Phosgene.getFluidOrGas(1000)).duration(2 * SECONDS + 10 * TICKS)
+                .eut(TierEU.RECIPE_HV).addTo(UniversalChemical);
 
         // COCl2 + C2H6O = HCl + C3H5ClO2
         GT_Values.RA.addChemicalRecipe(


### PR DESCRIPTION
resolves the second part of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13605;
thus closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13605.
Also uses ra2 for the phosgen recipes and removed/fixed the broken variants. (+bs update+dep update to get new gt in particular)