### PR TITLE
Remove outdated botdustries fluids

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,15 +1,15 @@
 // Add your dependencies here
 
 dependencies {
-    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.65:dev')
-    compile('com.github.GTNewHorizons:NewHorizonsCoreMod:2.1.44:dev')
+    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.73:dev')
+    compile('com.github.GTNewHorizons:NewHorizonsCoreMod:2.1.45:dev')
     compile('com.github.GTNewHorizons:StructureLib:1.2.7:dev')
-    compile('com.github.GTNewHorizons:GTplusplus:1.9.28:dev')
+    compile('com.github.GTNewHorizons:GTplusplus:1.9.33:dev')
     compile('com.github.GTNewHorizons:GoodGenerator:0.6.9:dev')
-    compile('com.github.GTNewHorizons:TecTech:5.2.20:dev')
+    compile('com.github.GTNewHorizons:TecTech:5.2.21:dev')
     compile('com.github.GTNewHorizons:ForestryMC:4.6.7:dev')
     compile('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-217-GTNH:dev')
-    compile('com.github.GTNewHorizons:bartworks:0.7.15:dev')
+    compile('com.github.GTNewHorizons:bartworks:0.7.16:dev')
     compile('com.github.GTNewHorizons:BuildCraft:7.1.33:dev')
     compile('com.github.GTNewHorizons:NotEnoughItems:2.3.54-GTNH:dev')
 
@@ -18,13 +18,13 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:EnderCore:0.2.14:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:AppleCore:3.2.10:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Railcraft:9.14.3:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:EnderIO:2.4.17:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:EnderIO:2.4.18:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.34:dev') {transitive=false}
 
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev') {transitive=false}
 
     //compile('com.github.GTNewHorizons:GalacticGregGT5:1.0.9:dev')
-    //compile('com.github.GTNewHorizons:TecTech:5.2.20:dev')
+    //compile('com.github.GTNewHorizons:TecTech:5.2.21:dev')
     //compile('com.github.GTNewHorizons:Galacticraft:3.0.68-GTNH:dev')
 
     //compileOnly('com.github.GTNewHorizons:Avaritia:1.42

--- a/src/main/java/com/elisis/gtnhlanth/common/register/BotWerkstoffMaterialPool.java
+++ b/src/main/java/com/elisis/gtnhlanth/common/register/BotWerkstoffMaterialPool.java
@@ -5,8 +5,6 @@ import static com.github.bartimaeusnek.bartworks.util.BW_Util.subscriptNumbers;
 import static gregtech.api.enums.Materials.*;
 import static gregtech.api.enums.TextureSet.*;
 
-import net.minecraft.util.EnumChatFormatting;
-
 import com.github.bartimaeusnek.bartworks.system.material.Werkstoff;
 import com.github.bartimaeusnek.bartworks.util.Pair;
 
@@ -15,9 +13,6 @@ import com.github.bartimaeusnek.bartworks.util.Pair;
  */
 @SuppressWarnings("unchecked")
 public class BotWerkstoffMaterialPool implements Runnable {
-
-    private static final String DEPRECATED = EnumChatFormatting.DARK_RED
-            + "Deprecated; Will be removed in the next update";
 
     public static final Werkstoff TungsticAcid = new Werkstoff(
             new short[] { 0xf5, 0xf1, 0x16 },
@@ -133,15 +128,6 @@ public class BotWerkstoffMaterialPool implements Runnable {
             new Werkstoff.GenerationFeatures().disable().addCells(),
             29912,
             SET_FINE);
-    public static final Werkstoff LMP103S = new Werkstoff(
-            new short[] { 0xbf, 0x2f, 0xc2 },
-            "LMP-103S",
-            DEPRECATED,
-            new Werkstoff.Stats(),
-            COMPOUND,
-            new Werkstoff.GenerationFeatures().disable().addCells(),
-            29913,
-            SET_FINE);
     public static final Werkstoff OXylene = new Werkstoff(
             new short[] { 0x88, 0x94, 0xa8 },
             "O-Xylene",
@@ -240,24 +226,6 @@ public class BotWerkstoffMaterialPool implements Runnable {
             COMPOUND,
             new Werkstoff.GenerationFeatures().disable().addCells(),
             29928,
-            SET_METALLIC);
-    public static final Werkstoff MonomethylhydrazineFuelMix = new Werkstoff(
-            new short[] { 0x78, 0xe3, 0xa7 },
-            "Monomethylhydrazine Fuel Mix",
-            DEPRECATED,
-            new Werkstoff.Stats(),
-            COMPOUND,
-            new Werkstoff.GenerationFeatures().disable().addCells(),
-            29929,
-            SET_METALLIC);
-    public static final Werkstoff UnsymmetricalDimethylhydrazineFuelMix = new Werkstoff(
-            new short[] { 0xc8, 0xff, 0x00 },
-            "Unsymmetrical Dimethylhydrazine Fuel Mix",
-            DEPRECATED,
-            new Werkstoff.Stats(),
-            COMPOUND,
-            new Werkstoff.GenerationFeatures().disable().addCells(),
-            29930,
             SET_METALLIC);
     public static final Werkstoff Nitromethane = new Werkstoff(
             new short[] { 0x87, 0x7d, 0x60 },

--- a/src/main/java/com/elisis/gtnhlanth/common/register/BotWerkstoffMaterialPool.java
+++ b/src/main/java/com/elisis/gtnhlanth/common/register/BotWerkstoffMaterialPool.java
@@ -40,18 +40,6 @@ public class BotWerkstoffMaterialPool implements Runnable {
             SET_SHINY,
             new Pair<>(Tungsten, 1),
             new Pair<>(Oxygen, 3));
-    // public static final Werkstoff TungstenSteelOxide = new Werkstoff(
-    // new short[]{0x1f,0x27,0x69},
-    // "Tungstensteel Oxide",
-    // new Werkstoff.Stats(),
-    // COMPOUND,
-    // new Werkstoff.GenerationFeatures().onlyDust(),
-    // 29902,
-    // SET_FINE,
-    // new Pair<>(Tungsten, 1),
-    // new Pair<>(Oxygen,3),
-    // new Pair<>(Steel,1)
-    // );
     public static final Werkstoff AmmoniumNitrate = new Werkstoff(
             new short[] { 0x81, 0xcc, 0x00 },
             "Ammonium Nitrate",
@@ -208,24 +196,6 @@ public class BotWerkstoffMaterialPool implements Runnable {
             new Werkstoff.GenerationFeatures().disable().addCells(),
             29920,
             SET_METALLIC);
-    public static final Werkstoff HydrogenPeroxide = new Werkstoff(
-            new short[] { 0xad, 0x53, 0x1a },
-            "Hydrogen Peroxide",
-            subscriptNumbers("H2O2"),
-            new Werkstoff.Stats(),
-            COMPOUND,
-            new Werkstoff.GenerationFeatures().disable().addCells().enforceUnification(),
-            29921,
-            SET_METALLIC);
-    public static final Werkstoff Hydrazine = new Werkstoff(
-            new short[] { 0xb5, 0x07, 0x07 },
-            "hydrazine",
-            subscriptNumbers("N2H4"),
-            new Werkstoff.Stats(),
-            COMPOUND,
-            new Werkstoff.GenerationFeatures().disable().addCells(),
-            29922,
-            SET_METALLIC);
     public static final Werkstoff DimethylSulfate = new Werkstoff(
             new short[] { 0xff, 0xfb, 0x00 },
             "Dimethyl Sulfate",
@@ -243,15 +213,6 @@ public class BotWerkstoffMaterialPool implements Runnable {
             COMPOUND,
             new Werkstoff.GenerationFeatures().disable().addCells(),
             29924,
-            SET_METALLIC);
-    public static final Werkstoff Formaldehyde = new Werkstoff(
-            new short[] { 0x2e, 0xd9, 0x83 },
-            "Formaldehyde",
-            subscriptNumbers("CH2O"),
-            new Werkstoff.Stats(),
-            COMPOUND,
-            new Werkstoff.GenerationFeatures().disable().addCells(),
-            29925,
             SET_METALLIC);
     public static final Werkstoff EthylAcetate = new Werkstoff(
             new short[] { 0x0c, 0xfb, 0x32b },

--- a/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
@@ -492,18 +492,19 @@ public class BotRecipes {
                     null,
                     40,
                     30_720);
-        }
 
-        // C2H6N2O + 2CH2O + 4H = C2H8N2 + C2H4O2 + H2O
-        GT_Values.RA.addMultiblockChemicalRecipe(
-                new ItemStack[] { C2 },
-                new FluidStack[] { Acetylhydrazine.getFluidOrGas(1000), Formaldehyde.getFluidOrGas(2000),
-                        Materials.Hydrogen.getGas(4000) },
-                new FluidStack[] { UnsymmetricalDimethylhydrazine.getFluidOrGas(1000),
-                        Materials.AceticAcid.getFluid(1000), Materials.Water.getFluid(1000) },
-                null,
-                20,
-                122_880);
+            // C2H6N2O + 2CH2O + 4H = C2H8N2 + C2H4O2 + H2O
+            GT_Values.RA.addMultiblockChemicalRecipe(
+                    new ItemStack[] { C2 },
+                    new FluidStack[] { Acetylhydrazine.getFluidOrGas(1000),
+                            new FluidStack(FluidRegistry.getFluid("fluid.formaldehyde"), 2000),
+                            Materials.Hydrogen.getGas(4000) },
+                    new FluidStack[] { UnsymmetricalDimethylhydrazine.getFluidOrGas(1000),
+                            Materials.AceticAcid.getFluid(1000), Materials.Water.getFluid(1000) },
+                    null,
+                    20,
+                    122_880);
+        }
     }
 
     public static void addFuels() {

--- a/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
@@ -1,7 +1,9 @@
 package com.elisis.gtnhlanth.loader;
 
 import static com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool.*;
+import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.enums.OrePrefixes.*;
+import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sChemicalRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
@@ -15,6 +17,7 @@ import java.util.HashSet;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool;
@@ -382,16 +385,6 @@ public class BotRecipes {
                 1400,
                 7680);
 
-        // H2O2 + 2NH3 = N2H4 + 2H2O
-        GT_Values.RA.addChemicalRecipe(
-                HydrogenPeroxide.get(cell, 1),
-                C2,
-                Materials.Ammonia.getGas(2000),
-                Materials.Water.getFluid(2000),
-                Hydrazine.get(cell, 1),
-                100,
-                120);
-
         // 2CH4O + H2SO4 = C2H6O4S + 2H2O
         GT_Values.RA.addChemicalRecipe(
                 Materials.SulfuricAcid.getCells(1),
@@ -412,16 +405,18 @@ public class BotRecipes {
                 50,
                 480);
 
-        // N2H4 + C2H6O4S = SO3 + CH6N2 + CH4O
-        GT_Values.RA.addChemicalRecipe(
-                Hydrazine.get(cell, 1),
-                Materials.Empty.getCells(1),
-                DimethylSulfate.getFluidOrGas(1000),
-                Materials.SulfurTrioxide.getGas(1000),
-                Monomethylhydrazine.get(cell, 1),
-                Materials.Methanol.getCells(1),
-                80,
-                16000);
+        if (GTPlusPlus.isModLoaded()) {
+            // N2H4 + C2H6O4S = SO3 + CH6N2 + CH4O
+            GT_Values.RA.addChemicalRecipe(
+                    getModItem(GTPlusPlus.ID, "Hydrazine", 1),
+                    Materials.Empty.getCells(1),
+                    DimethylSulfate.getFluidOrGas(1000),
+                    Materials.SulfurTrioxide.getGas(1000),
+                    Monomethylhydrazine.get(cell, 1),
+                    Materials.Methanol.getCells(1),
+                    80,
+                    16000);
+        }
 
         /*
          * GT_Values.RA.addMixerRecipe( AmmoniumDinitramide.get(cell, 1), C1, null, null,
@@ -536,15 +531,17 @@ public class BotRecipes {
                 100,
                 480);
 
-        // N2H4 + C2H4O2 =C2H6O= C2H6N2O + H2O
-        GT_Values.RA.addMultiblockChemicalRecipe(
-                new ItemStack[] { C2 },
-                new FluidStack[] { Materials.AceticAcid.getFluid(1000), Materials.Ethanol.getFluid(1000),
-                        Hydrazine.getFluidOrGas(1000) },
-                new FluidStack[] { Acetylhydrazine.getFluidOrGas(1000), Materials.Ethanol.getFluid(1000) },
-                null,
-                40,
-                30_720);
+        if (GTPlusPlus.isModLoaded()) {
+            // N2H4 + C2H4O2 =C2H6O= C2H6N2O + H2O
+            GT_Values.RA.addMultiblockChemicalRecipe(
+                    new ItemStack[] { C2 },
+                    new FluidStack[] { Materials.AceticAcid.getFluid(1000), Materials.Ethanol.getFluid(1000),
+                            new FluidStack(FluidRegistry.getFluid("fluid.hydrazine"), 1000) },
+                    new FluidStack[] { Acetylhydrazine.getFluidOrGas(1000), Materials.Ethanol.getFluid(1000) },
+                    null,
+                    40,
+                    30_720);
+        }
 
         // C2H6N2O + 2CH2O + 4H = C2H8N2 + C2H4O2 + H2O
         GT_Values.RA.addMultiblockChemicalRecipe(

--- a/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
@@ -116,10 +116,6 @@ public class BotRecipes {
         // H2WO4 = WO3 + H2O
         GT_Values.RA.addBlastRecipe(H2WO4, null, null, null, WO3, null, 200, 480, 1200);
 
-        // ItemStack WO3Fe = TungstenSteelOxide.get(dust, 2);
-        // GT_Values.RA.addMixerRecipe(WO3, Materials.Steel.getDust(1), null, null, null, null,
-        // WO3Fe, 100, 1920);
-
         // WO3 + 6H = W + 3H2O
         GT_Values.RA.addBlastRecipe(
                 WO3,
@@ -224,13 +220,6 @@ public class BotRecipes {
                 AmmoniumDinitramide.get(cell, 1),
                 200,
                 1920);
-
-        // LMP-103S
-        /*
-         * GT_Values.RA.addMultiblockChemicalRecipe( new ItemStack[] {C24}, new FluidStack[] {
-         * AmmoniumDinitramide.getFluidOrGas(6000), Materials.Methanol.getFluid(2000), Materials.Ammonia.getGas(500),
-         * Materials.Water.getFluid(1500) }, new FluidStack[] {LMP103S.getFluidOrGas(10000)}, null, 1200, 1920);
-         */
 
         // P4O10 + 2HNO3 + 5H2O = 4H3PO4 + N2O5
         GT_Values.RA.addChemicalRecipe(
@@ -418,12 +407,6 @@ public class BotRecipes {
                     16000);
         }
 
-        /*
-         * GT_Values.RA.addMixerRecipe( AmmoniumDinitramide.get(cell, 1), C1, null, null,
-         * Monomethylhydrazine.getFluidOrGas(2000), MonomethylhydrazineFuelMix.getFluidOrGas(3000), cells, 20, 480);
-         * cells.stackSize = 2; GT_Values.RA.addMixerRecipe( Monomethylhydrazine.get(cell, 2), C2, null, null,
-         * AmmoniumDinitramide.getFluidOrGas(1000), MonomethylhydrazineFuelMix.getFluidOrGas(3000), cells, 20, 480);
-         */
         cells.stackSize = 1;
 
         // unsimetrical hydazine
@@ -553,14 +536,6 @@ public class BotRecipes {
                 null,
                 20,
                 122_880);
-
-        /*
-         * cells.stackSize = 2; GT_Values.RA.addMixerRecipe( UnsymmetricalDimethylhydrazine.get(cell, 2), C2, null,
-         * null, Trinitramid.getFluidOrGas(1000), UnsymmetricalDimethylhydrazineFuelMix.getFluidOrGas(3000), cells, 10,
-         * 120); cells.stackSize = 1; GT_Values.RA.addMixerRecipe( Trinitramid.get(cell, 1), C2, null, null,
-         * UnsymmetricalDimethylhydrazine.getFluidOrGas(2000),
-         * UnsymmetricalDimethylhydrazineFuelMix.getFluidOrGas(3000), cells, 10, 120);
-         */
     }
 
     public static void addFuels() {

--- a/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
@@ -352,28 +352,6 @@ public class BotRecipes {
                 1200,
                 7680);
 
-        // 2C18H17O2 + 2O = 2C18H16O2 + H2O2
-        GT_Values.RA.addChemicalRecipe(
-                Materials.Oxygen.getCells(2),
-                C2,
-                TwoTertButylAnthrahydroquinone.getFluidOrGas(2000),
-                TwoTertButylAnthraquinone.getFluidOrGas(2000),
-                HydrogenPeroxide.get(cell, 1),
-                Materials.Empty.getCells(1),
-                40,
-                1920);
-
-        // 2H + 2O =C18H16O2,Pd= H2O2
-        GT_Values.RA.addMultiblockChemicalRecipe(
-                new ItemStack[] { C24, Materials.Palladium.getDustTiny(1) },
-                new FluidStack[] { Materials.Hydrogen.getGas(10000), Materials.Oxygen.getGas(10000),
-                        TwoTertButylAnthraquinone.getFluidOrGas(10000) },
-                new FluidStack[] { HydrogenPeroxide.getFluidOrGas(5000),
-                        TwoTertButylAnthraquinone.getFluidOrGas(10000) },
-                null,
-                1400,
-                7680);
-
         // 2CH4O + H2SO4 = C2H6O4S + 2H2O
         GT_Values.RA.addChemicalRecipe(
                 Materials.SulfuricAcid.getCells(1),

--- a/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
@@ -9,21 +9,16 @@ import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_RecipeConstants.UniversalChemical;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashSet;
 
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.elisis.gtnhlanth.common.register.BotWerkstoffMaterialPool;
 import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 
-import cpw.mods.fml.common.Loader;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.TierEU;
@@ -508,34 +503,6 @@ public class BotRecipes {
     }
 
     public static void addFuels() {
-        try {
-            if (Loader.isModLoaded(GT_Values.MOD_ID_GC_CORE)) {
-                Class<?> rocket = Class.forName("micdoodle8.mods.galacticraft.api.recipe.RocketFuelRecipe");
-                Method addFuel = rocket.getMethod("addFuel", Fluid.class, int.class);
-                addFuel.invoke(null, LMP103S.getFluidOrGas(1).getFluid(), 4);
-                addFuel.invoke(null, MonomethylhydrazineFuelMix.getFluidOrGas(1).getFluid(), 6);
-                addFuel.invoke(null, UnsymmetricalDimethylhydrazineFuelMix.getFluidOrGas(1).getFluid(), 8);
-            }
-            if (Loader.isModLoaded("miscutils")) {
-                Class<?> gtppRecipeMap = Class.forName("gregtech.api.util.GTPP_Recipe$GTPP_Recipe_Map");
-                Field rocketFuels = gtppRecipeMap.getDeclaredField("sRocketFuels");
-                rocketFuels.setAccessible(true);
-                Class<?> rocketFuelsClass = rocketFuels.getType();
-                Object rocketFuelsObject = rocketFuels.get(null);
-                Method addFuel = rocketFuelsClass
-                        .getDeclaredMethod("addFuel", FluidStack.class, FluidStack.class, int.class);
-                addFuel.invoke(rocketFuelsObject, LMP103S.getFluidOrGas(1000), null, 666);
-                addFuel.invoke(rocketFuelsObject, MonomethylhydrazineFuelMix.getFluidOrGas(1000), null, 1500);
-                addFuel.invoke(
-                        rocketFuelsObject,
-                        UnsymmetricalDimethylhydrazineFuelMix.getFluidOrGas(1000),
-                        null,
-                        3000);
-            }
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException
-                | NoSuchFieldException e) {
-            e.printStackTrace();
-        }
         GT_Recipe.GT_Recipe_Map.sTurbineFuels.addFuel(TertButylbenzene.get(cell, 1), null, 420);
     }
 

--- a/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/BotRecipes.java
@@ -482,16 +482,6 @@ public class BotRecipes {
                 50,
                 1920);
 
-        // O + CH4O =Ag= CH2O
-        GT_Values.RA.addChemicalRecipe(
-                Materials.Oxygen.getCells(4),
-                Materials.Silver.getDustTiny(1),
-                Materials.Methanol.getFluid(4000),
-                Formaldehyde.getFluidOrGas(4000),
-                cells,
-                100,
-                480);
-
         if (GTPlusPlus.isModLoaded()) {
             // N2H4 + C2H4O2 =C2H6O= C2H6N2O + H2O
             GT_Values.RA.addMultiblockChemicalRecipe(


### PR DESCRIPTION
requires https://github.com/GTNewHorizons/GT5-Unofficial/pull/2059. (done.)

Removes the botdustries variants of Hydrazine, Hydrogen Peroxide, and Formaldehyde as well as related recipes. A deprecation before removal was attempted but unsuccessful as the fluids are in part merged with their gt++ counterparts.

Also removes LMP-103S, Monomethylhydrazine Fuel Mix, and UnsymmetricalDimethylhydrazineFuelMix. These are the fuels which have been deprecated for a while. (2 stables)

Not a high priority but this should get follow ups in GT++ (no more conversion and alternative recipes needed) and goodgen (no more alternative recipes needed). Might also want to remove the GT++ phthallic acid in favour of the gt one in a similar spirit.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12369. Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10847. Also fixes parts of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10839 and https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10208.