### PR TITLE
EuO chem balance fix

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -663,7 +663,7 @@ public class RecipeLoader {
                 Materials.Europium.getDust(1),
                 null,
                 null,
-                WerkstoffMaterialPool.EuropiumOxide.get(OrePrefixes.dust, 4),
+                WerkstoffMaterialPool.EuropiumOxide.get(OrePrefixes.dust, 6),
                 300,
                 8400);
 


### PR DESCRIPTION
A simple chem balance fix. 3 Eu + 3O go in, so 3Eu + 3O should go out. there is no intentional loss here as far as I am aware.

there was already an attempt to fix it in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/68 but somehow that didnt make the redo of the PR after initial revert.

recipe now:
![image](https://github.com/GTNewHorizons/GTNH-Lanthanides/assets/40274384/a24c2cc4-491b-4e7d-bc59-11960a482ac4)
