### PR TITLE
Fix Digester & Dissolution Tank NEI previews

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/common/tileentity/Digester.java
+++ b/src/main/java/com/elisis/gtnhlanth/common/tileentity/Digester.java
@@ -2,15 +2,21 @@ package com.elisis.gtnhlanth.common.tileentity;
 
 import static com.elisis.gtnhlanth.util.DescTextLocalization.BLUEPRINT_INFO;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
+import static gregtech.api.enums.GT_HatchElement.Energy;
+import static gregtech.api.enums.GT_HatchElement.InputBus;
+import static gregtech.api.enums.GT_HatchElement.InputHatch;
+import static gregtech.api.enums.GT_HatchElement.Maintenance;
+import static gregtech.api.enums.GT_HatchElement.Muffler;
+import static gregtech.api.enums.GT_HatchElement.OutputBus;
+import static gregtech.api.enums.GT_HatchElement.OutputHatch;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER_ACTIVE;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER_ACTIVE_GLOW;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER_GLOW;
 import static gregtech.api.enums.Textures.BlockIcons.casingTexturePages;
+import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
 import static gregtech.api.util.GT_StructureUtility.ofCoil;
-import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 
 import java.util.ArrayList;
 
@@ -20,7 +26,6 @@ import net.minecraftforge.fluids.FluidStack;
 
 import com.elisis.gtnhlanth.api.recipe.LanthanidesRecipeMaps;
 import com.elisis.gtnhlanth.util.DescTextLocalization;
-import com.gtnewhorizon.structurelib.alignment.constructable.IConstructable;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
@@ -37,8 +42,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 
-public class Digester extends GT_MetaTileEntity_EnhancedMultiBlockBase<Digester>
-        implements IConstructable, ISurvivalConstructable {
+public class Digester extends GT_MetaTileEntity_EnhancedMultiBlockBase<Digester> implements ISurvivalConstructable {
 
     protected int casingAmount = 0;
     protected int height = 0;
@@ -52,15 +56,12 @@ public class Digester extends GT_MetaTileEntity_EnhancedMultiBlockBase<Digester>
                             { "  ttt  ", " t---t ", "t-----t", "t-----t", "t-----t", " t---t ", "  ttt  " },
                             { " tccct ", "tc---ct", "c-----c", "c-----c", "c-----c", "tc---ct", " tccct " },
                             { " tt~tt ", "thhhhht", "thsssht", "thsssht", "thsssht", "thhhhht", " ttttt " }, }))
+
             .addElement(
                     't',
-                    ofChain(
-                            ofHatchAdder(Digester::addInputToMachineList, 47, 1),
-                            ofHatchAdder(Digester::addOutputToMachineList, 47, 1),
-                            ofHatchAdder(Digester::addEnergyInputToMachineList, 47, 1),
-                            ofHatchAdder(Digester::addMaintenanceToMachineList, 47, 1),
-                            ofHatchAdder(Digester::addMufflerToMachineList, 47, 1),
-                            ofBlock(GregTech_API.sBlockCasings4, 0)))
+                    buildHatchAdder(Digester.class)
+                            .atLeast(InputHatch, OutputHatch, InputBus, OutputBus, Maintenance, Energy, Muffler)
+                            .casingIndex(47).dot(1).buildAndChain(GregTech_API.sBlockCasings4, 0))
             .addElement('h', ofBlock(GregTech_API.sBlockCasings1, 11))
             .addElement('s', ofBlock(GregTech_API.sBlockCasings4, 1))
             .addElement('c', ofCoil(Digester::setCoilLevel, Digester::getCoilLevel)).build();

--- a/src/main/java/com/elisis/gtnhlanth/common/tileentity/DissolutionTank.java
+++ b/src/main/java/com/elisis/gtnhlanth/common/tileentity/DissolutionTank.java
@@ -3,14 +3,20 @@ package com.elisis.gtnhlanth.common.tileentity;
 import static com.elisis.gtnhlanth.util.DescTextLocalization.BLUEPRINT_INFO;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlockAdder;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
+import static gregtech.api.enums.GT_HatchElement.Energy;
+import static gregtech.api.enums.GT_HatchElement.InputBus;
+import static gregtech.api.enums.GT_HatchElement.InputHatch;
+import static gregtech.api.enums.GT_HatchElement.Maintenance;
+import static gregtech.api.enums.GT_HatchElement.Muffler;
+import static gregtech.api.enums.GT_HatchElement.OutputBus;
+import static gregtech.api.enums.GT_HatchElement.OutputHatch;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER_ACTIVE;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER_ACTIVE_GLOW;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER_GLOW;
 import static gregtech.api.enums.Textures.BlockIcons.casingTexturePages;
-import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
+import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
 
 import java.util.List;
 
@@ -22,7 +28,6 @@ import net.minecraftforge.fluids.FluidStack;
 import com.elisis.gtnhlanth.api.recipe.LanthanidesRecipeMaps;
 import com.elisis.gtnhlanth.util.DescTextLocalization;
 import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
-import com.gtnewhorizon.structurelib.alignment.constructable.IConstructable;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
@@ -40,7 +45,7 @@ import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 
 public class DissolutionTank extends GT_MetaTileEntity_EnhancedMultiBlockBase<DissolutionTank>
-        implements IConstructable, ISurvivalConstructable, ISecondaryDescribable {
+        implements ISurvivalConstructable, ISecondaryDescribable {
 
     private final IStructureDefinition<DissolutionTank> multiDefinition = StructureDefinition.<DissolutionTank>builder()
             .addShape(
@@ -53,13 +58,9 @@ public class DissolutionTank extends GT_MetaTileEntity_EnhancedMultiBlockBase<Di
                                     { "s   s", "     ", "     ", "     ", "s   s" } }))
             .addElement(
                     's',
-                    ofChain(
-                            ofHatchAdder(DissolutionTank::addInputToMachineList, 49, 1),
-                            ofHatchAdder(DissolutionTank::addOutputToMachineList, 49, 1),
-                            ofHatchAdder(DissolutionTank::addEnergyInputToMachineList, 49, 1),
-                            ofHatchAdder(DissolutionTank::addMaintenanceToMachineList, 49, 1),
-                            ofHatchAdder(DissolutionTank::addMufflerToMachineList, 49, 1),
-                            ofBlock(GregTech_API.sBlockCasings4, 1)))
+                    buildHatchAdder(DissolutionTank.class)
+                            .atLeast(InputHatch, OutputHatch, InputBus, OutputBus, Maintenance, Energy, Muffler)
+                            .casingIndex(49).dot(1).buildAndChain(GregTech_API.sBlockCasings4, 1))
             .addElement('h', ofBlock(GregTech_API.sBlockCasings1, 11))
             .addElement('g', ofBlockAdder(DissolutionTank::addGlass, ItemRegistry.bw_glasses[0], 1)).build();
 


### PR DESCRIPTION
ofHatchAdder defaults to IStructureElementNoPlacement as opposed to IStructureElement if no shouldSkip predicate is defined. This doesn't allow the hatches to be placed in survival mode which BlockRenderer respects and causes no hatches to be shown in NEI.

Using the buildHatchAdder method we can do that a bit easier. This also lets the hologram projector place the hatches which leaves less guesswork for the players.

![digester](https://github.com/GTNewHorizons/GTNH-Lanthanides/assets/127234178/8da83a59-58ec-417e-9dc1-a1af85693a13)
![disstank](https://github.com/GTNewHorizons/GTNH-Lanthanides/assets/127234178/a451f911-e622-471f-a166-eeab71730ccf)

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15341