### PR TITLE
Fixing Raw Ores and removed old commented out code

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.46.05:dev')
-    implementation('com.github.GTNewHorizons:GTplusplus:1.12.2:dev')
-    implementation('com.github.GTNewHorizons:GoodGenerator:0.9.1:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.46.23:dev')
+    implementation('com.github.GTNewHorizons:GTplusplus:1.12.10:dev')
+    implementation('com.github.GTNewHorizons:GoodGenerator:0.9.5:dev')
 }

--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -2506,8 +2506,9 @@ public class RecipeLoader {
             if (GT_Utility.isStackValid(input)) {
                 int[] oreDict = OreDictionary.getOreIDs(input);
                 for (int oreDictID : oreDict) {
-                    if ((OreDictionary.getOreName(oreDictID).startsWith("ore") || OreDictionary.getOreName(oreDictID)
-                            .startsWith("crushed")) /* && OreDictionary.getOreName(oreDictID).contains("Cerium") */) {
+                    if ((OreDictionary.getOreName(oreDictID).startsWith("ore")
+                            || OreDictionary.getOreName(oreDictID).startsWith("rawOre")
+                            || OreDictionary.getOreName(oreDictID).startsWith("crushed"))) {
                         GT_Log.out.print(OreDictionary.getOreName(oreDictID));
                         GT_Recipe tRecipe = recipe.copy();
                         boolean modified = false;


### PR DESCRIPTION
Fixing the wrong secondary output of raw ores.
Together with: https://github.com/GTNewHorizons/GoodGenerator/pull/258

Part of fixing: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15984

![image](https://github.com/GTNewHorizons/GTNH-Lanthanides/assets/3237986/70901bd0-666a-4953-aadf-a3557de97861)
